### PR TITLE
fix(postgres): wire CNPG-i barman recovery source + re-enable db apps

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
   # - ./readmeabook/ks.yaml
   - ./seerr/ks.yaml
   - ./tautulli/ks.yaml
-  # - ./tracearr/ks.yaml
+  - ./tracearr/ks.yaml

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -10,7 +10,7 @@ components:
 resources:
   - ./actual/ks.yaml
   - ./baby-tracker/ks.yaml
-  # - ./bambuddy/ks.yaml
-  # - ./lubelog/ks.yaml
-  # - ./sparkyfitness/ks.yaml
-  # - ./teslamate/ks.yaml
+  - ./bambuddy/ks.yaml
+  - ./lubelog/ks.yaml
+  - ./sparkyfitness/ks.yaml
+  - ./teslamate/ks.yaml

--- a/kubernetes/components/postgres/cluster.yaml
+++ b/kubernetes/components/postgres/cluster.yaml
@@ -44,24 +44,13 @@ spec:
       source: &archive ${APP}-backup-archive
       database: ${APP}
       owner: ${APP}
-  # # # Note: externalClusters is needed when recovering from an existing cnpg cluster
-  # externalClusters:
-  #   - name: *archive
-  #     barmanObjectStore: &barman
-  #       destinationPath: s3://postgresql
-  #       serverName: ${APP}
-  #       endpointURL: https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
-  #       s3Credentials:
-  #         accessKeyId:
-  #           name: ${APP}-postgres-secret
-  #           key: AWS_ACCESS_KEY_ID
-  #         secretAccessKey:
-  #           name: ${APP}-postgres-secret
-  #           key: AWS_SECRET_ACCESS_KEY
-  #       wal:
-  #         compression: bzip2
-  #       data:
-  #         compression: bzip2
-  # backup:
-  #   barmanObjectStore: *barman
-  #   retentionPolicy: 7d
+  # Recovery source for bootstrap.recovery: resolve ${APP}-backup-archive via the
+  # barman-cloud CNPG-i plugin against the cloudflare-r2 ObjectStore. serverName
+  # must match the name the source archived under (same-name rebuild => ${APP}).
+  externalClusters:
+    - name: *archive
+      plugin:
+        name: *plugin
+        parameters:
+          barmanObjectName: cloudflare-r2
+          serverName: ${APP}


### PR DESCRIPTION
Follow-up to #947, whose merge accidentally swept in incomplete WIP (an active `bootstrap.recovery` with no recovery source, plus several disabled app kustomizations). Per the intended plan (restore DBs from R2 backup, keep all apps enabled):

## Changes
- **`components/postgres/cluster.yaml`** — define `externalClusters[].plugin` (barman-cloud CNPG-i plugin → `cloudflare-r2` ObjectStore, `serverName: ${APP}`) so `bootstrap.recovery.source: ${APP}-backup-archive` resolves. Replaces the commented-out deprecated `barmanObjectStore` form. **Validated via server-side dry-run** — the CNPG webhook now accepts the Cluster (previously rejected: "external cluster ... not found / missing CNPG-i configuration").
- **Re-enable** the app kustomizations disabled by the sweep: `teslamate`, `lubelog`, `sparkyfitness`, `bambuddy` (selfhosted) and `tracearr` (media).

## Effect
Each per-app CNPG cluster restores from its R2 Barman archive on the rebuild. Apps that have no prior backup would need the `components.postgres/cnpg: init` label (initdb) instead — call out if any of these are brand-new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)