### PR TITLE
feat(postgres): enable NFS logical restore CronJob as recovery fallback

### DIFF
--- a/kubernetes/components/postgres/kustomization.yaml
+++ b/kubernetes/components/postgres/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./cluster.yaml
   - ./externalsecret.yaml
   - ./jobs/backup.cronjob.yaml
-  # - ./jobs/restore.cronjob.yaml
+  - ./jobs/restore.cronjob.yaml
   - ./objectstore.yaml
   - ./scheduledbackup.yaml
 patches:


### PR DESCRIPTION
## What

Enables the `${APP}-postgres-restore` CronJob (previously commented out) in the shared `components/postgres` kustomization. Every app using the postgres component now gets the restore CronJob deployed **suspended** and on an impossible schedule — it never fires on its own and must be triggered manually.

## Why

Restore strategy is **Barman/R2 `bootstrap.recovery` primary, NFS logical restore fallback**:

- Clusters bootstrap by physically recovering from Cloudflare R2 via the barman-cloud CNPG-i plugin (already committed in #948).
- For any app whose R2 archive is missing/corrupt, the cluster fails to bootstrap. That app can be switched to an empty `initdb` bootstrap and then re-seeded from its `prodrigestivill` logical dump on NFS (`yemoja.internal:/mnt/alaafin/k8s/postgres`) using this CronJob.

`restore.sh` restores `<dbname>-latest.sql.gz`, and `recovery.database`/`initdb.database` both set `dbname=${APP}`, which matches the per-app dump names already on the share (`lubelog-latest.sql.gz`, `teslamate-latest.sql.gz`, …).

## Trigger (manual, per app)

```bash
kubectl -n <ns> create job --from=cronjob/<app>-postgres-restore <app>-restore-$(date +%s)
```

## Notes

- **teslamate**: dump is ~277 MB compressed vs the shared 5Gi cluster volume — may need a storage bump if restored.
- **tracearr**: no logical dump on NFS — depends entirely on R2 recovery, no fallback.
- **sparkyfitness**: latest NFS dump is stale (Apr 8); prefer R2 recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)