### PR TITLE
fix(baby-tracker): bootstrap empty for NFS logical restore

### DIFF
--- a/kubernetes/apps/selfhosted/baby-tracker/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/baby-tracker/app/kustomization.yaml
@@ -5,3 +5,19 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
+# EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
+# baby-tracker-postgres-restore Job (restores baby-tracker-latest.sql.gz).
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters


### PR DESCRIPTION
## What

Overrides the shared `components/postgres` `bootstrap.recovery` (R2/barman) with an empty `initdb` bootstrap for **baby-tracker** only, via a JSON6902 patch in the app's `app/kustomization.yaml`. `externalClusters` is removed; the WAL-archiver plugin/`serverName` is retained so ongoing backups continue.

## Why

We're seeding baby-tracker from its **NFS logical dump** (`baby-tracker-latest.sql.gz`) rather than physical R2 recovery. A `bootstrap.recovery` cluster can't simply be re-seeded logically, so it must first come up empty.

## Deploy / restore steps (manual, on-cluster)

1. Merge + reconcile so the patched Cluster renders with `initdb`.
2. If the cluster already exists, delete it (and its PVCs) so it re-bootstraps empty:
   ```bash
   kubectl -n selfhosted delete cluster baby-tracker-db
   ```
3. Once `baby-tracker-db` is Ready (empty), trigger the logical restore:
   ```bash
   kubectl -n selfhosted create job --from=cronjob/baby-tracker-postgres-restore baby-tracker-restore-$(date +%s)
   kubectl -n selfhosted logs -f job/baby-tracker-restore-<ts>
   ```

Scoped to baby-tracker; other apps still default to R2 recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)