### PR TITLE
fix(postgres): bootstrap empty for NFS restore (5 apps)

### DIFF
--- a/kubernetes/apps/media/readmeabook/app/kustomization.yaml
+++ b/kubernetes/apps/media/readmeabook/app/kustomization.yaml
@@ -6,3 +6,19 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
+# EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
+# readmeabook-postgres-restore Job (cnpg-6u9f bucket has no base backups yet).
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters

--- a/kubernetes/apps/media/tracearr/app/kustomization.yaml
+++ b/kubernetes/apps/media/tracearr/app/kustomization.yaml
@@ -6,3 +6,20 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Bootstrap an EMPTY cluster (initdb) instead of R2 barman recovery, since the
+# cnpg-6u9f bucket has no base backups yet. NOTE: no tracearr NFS dump was found
+# on the share, so this cluster comes up empty with no seed — the app must
+# initialize its own schema on first start.
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters

--- a/kubernetes/apps/selfhosted/lubelog/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/lubelog/app/kustomization.yaml
@@ -6,3 +6,19 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
+# EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
+# lubelog-postgres-restore Job (cnpg-6u9f bucket has no base backups yet).
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters

--- a/kubernetes/apps/selfhosted/sparkyfitness/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/sparkyfitness/app/kustomization.yaml
@@ -6,3 +6,19 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
+# EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
+# sparkyfitness-postgres-restore Job (cnpg-6u9f bucket has no base backups yet).
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters

--- a/kubernetes/apps/selfhosted/teslamate/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/teslamate/app/kustomization.yaml
@@ -8,3 +8,21 @@ resources:
   - ./grafanadatasource.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+# Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
+# EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
+# teslamate-postgres-restore Job (cnpg-6u9f bucket has no base backups yet).
+# NOTE: teslamate dump is ~277MB compressed; the shared 5Gi cluster volume may
+# need bumping before/after restore.
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+    patch: |-
+      - op: replace
+        path: /spec/bootstrap
+        value:
+          initdb:
+            database: ${APP}
+            owner: ${APP}
+      - op: remove
+        path: /spec/externalClusters

--- a/kubernetes/components/postgres/objectstore.yaml
+++ b/kubernetes/components/postgres/objectstore.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cloudflare-r2
 spec:
   configuration:
-    destinationPath: s3://postgresql
+    destinationPath: s3://cnpg-6u9f
     endpointURL: https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
     s3Credentials:
       accessKeyId:


### PR DESCRIPTION
## What

Adds the empty-`initdb` bootstrap override (JSON6902 patch in each app's `app/kustomization.yaml`) to **lubelog, sparkyfitness, teslamate, tracearr, readmeabook** — the same override as baby-tracker (#950), so all six postgres apps come up empty instead of attempting R2 recovery.

## Why

The R2 backup bucket is migrating to `cnpg-6u9f`, which is **empty** — no base backups, so `bootstrap.recovery` can't seed any cluster. Each cluster bootstraps empty (`initdb`, database/owner = `${APP}`) and is re-seeded from its `prodrigestivill` NFS logical dump. This also fixes the original `dbname: app` issue, since `initdb.database/owner = ${APP}`.

Coupled with the pending `objectstore.yaml` switch to `cnpg-6u9f` (uncommitted in the tree) — these represent the same migration.

## Per-app notes

- **teslamate** — NFS dump ~277 MB compressed vs the shared **5Gi** cluster volume; may need a storage bump.
- **sparkyfitness** — latest NFS dump is stale (Apr 8), but it's the only seed available.
- **tracearr** — **no NFS dump** on the share → comes up empty, app self-initializes its schema.

## Restore per app (manual, on-cluster, after merge + reconcile)

```bash
# delete existing cluster/PVCs if it already bootstrapped, so it re-inits empty:
kubectl -n <ns> delete cluster <app>-db
# once Ready (empty):
kubectl -n <ns> create job --from=cronjob/<app>-postgres-restore <app>-restore-$(date +%s)
```
(lubelog/sparkyfitness/teslamate → `selfhosted`; tracearr/readmeabook → `media`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)