### PR TITLE
fix(teslamate): bump postgres storage to 20Gi for NFS restore

### DIFF
--- a/kubernetes/apps/selfhosted/teslamate/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/teslamate/app/kustomization.yaml
@@ -11,8 +11,8 @@ resources:
 # Restore from the NFS logical dump instead of R2 barman recovery: bootstrap an
 # EMPTY cluster (initdb) so bootstrap.recovery is skipped, then re-seed via the
 # teslamate-postgres-restore Job (cnpg-6u9f bucket has no base backups yet).
-# NOTE: teslamate dump is ~277MB compressed; the shared 5Gi cluster volume may
-# need bumping before/after restore.
+# Storage is bumped from the shared 5Gi default to 20Gi: teslamate's dump is
+# ~277MB compressed (multi-GB restored) and the DB keeps growing.
 patches:
   - target:
       group: postgresql.cnpg.io
@@ -26,3 +26,6 @@ patches:
             owner: ${APP}
       - op: remove
         path: /spec/externalClusters
+      - op: replace
+        path: /spec/storage/size
+        value: 20Gi


### PR DESCRIPTION
## What

Bumps teslamate's CNPG Cluster `storage.size` from the shared component default (**5Gi**) to **20Gi**, via an added `op: replace` on `/spec/storage/size` in the existing Cluster patch.

## Why

teslamate's NFS logical dump is ~277 MB compressed — multiple GB once restored, and the DB grows continuously with position/drive data. 5Gi risks the restore failing on disk space. 20Gi gives headroom to restore and grow.

Pairs with the empty-`initdb` bootstrap from #951 so teslamate can be re-seeded via `teslamate-postgres-restore`.

> Note: increasing a CNPG cluster's `storage.size` triggers a PVC expansion (requires an expandable StorageClass — longhorn is). Since this cluster is being recreated empty for the restore anyway, it comes up at 20Gi from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)