### PR TITLE
fix(postgres): drop bare ${PG_VER} from restore shell comment

### DIFF
--- a/kubernetes/components/postgres/jobs/restore.cronjob.yaml
+++ b/kubernetes/components/postgres/jobs/restore.cronjob.yaml
@@ -33,8 +33,8 @@ spec:
                 - -c
                 - |
                   set -eu
-                  # $$ escapes the $ so Flux postBuild substitution leaves these
-                  # for the shell at runtime (only ${APP}/${PG_VER} are Flux vars).
+                  # Note: the $$ prefix escapes $ so Flux postBuild substitution
+                  # leaves these variables for the shell to expand at runtime.
                   export PGPASSWORD="$$POSTGRES_PASSWORD"
                   FILE="$${POSTGRES_RESTORE_FILE:-}"
                   if [ -z "$$FILE" ] && [ -e "/backups/$${POSTGRES_DB}-latest.sql.gz" ]; then


### PR DESCRIPTION
## Problem

After #955, reconcile failed:
```
post build failed for 'CronJob.v1.batch/${APP}-postgres-restore':
envsubst error: variable not set (strict mode): "PG_VER"
```

## Root cause

The restore command's **inline shell comment** read:
```
# ... (only ${APP}/${PG_VER} are Flux vars).
```
That `${PG_VER}` is **bare (no `:=` default)**. Because the comment lives inside the `|` block scalar, kustomize keeps it in the rendered manifest, so Flux's per-resource strict substitution evaluated `${PG_VER}` → unset → error.

The image tag's `${PG_VER:=18}` was **not** the cause — it has a default and `backup.cronjob` uses the identical token without issue. Verified with `drone/envsubst` (the library Flux uses): only `APP` and `PG_VER` are ever looked up, and `${PG_VER:=18}` resolves to `18` cleanly.

## Fix

Reword the comment with no `${...}`. The resource's only genuine Flux variables are now `${APP}` (provided) and `${PG_VER:=18}` (defaulted) — same profile as the working backup CronJob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)