### PR TITLE
feat(scripts): quiesce app + reset DB before restore

### DIFF
--- a/scripts/postgres-restore-all.sh
+++ b/scripts/postgres-restore-all.sh
@@ -3,26 +3,31 @@
 # postgres-restore-all.sh — reconcile + re-seed the CNPG postgres apps from
 # their NFS logical dumps after the switch to empty (initdb) bootstrap.
 #
-# For each app it:
+# For each app WITH a dump it:
 #   1. reconciles the Flux Kustomization (pulls the merged initdb override),
 #   2. deletes the existing Cluster so CNPG re-bootstraps it EMPTY,
 #      (CNPG will not re-bootstrap a Cluster that already exists — it must be
 #       recreated for initdb to take effect; this also removes its PVCs),
 #   3. waits for the fresh empty Cluster to become Ready,
-#   4. triggers the <app>-postgres-restore Job and follows it to completion.
+#   4. QUIESCES the app (suspends its Flux Kustomization + HelmRelease and scales
+#      the workload to 0) so it can't (re)create its own schema mid-restore,
+#   5. RESETS the database (drops all user schemas) — apps self-migrate their
+#      schema on boot, which collides with the dump's CREATE SCHEMA,
+#   6. triggers the <app>-postgres-restore Job and follows it to completion,
+#   7. scales the app back and resumes Flux.
+# Apps with no dump (tracearr) are skipped and left app-initialized.
 #
-# DESTRUCTIVE: step 2 deletes each Cluster and its data volumes. Requires a
-# confirmation per app unless --yes is passed. Use --dry-run to preview.
+# DESTRUCTIVE: step 2 deletes each Cluster and its data volumes, and step 5
+# drops all user schemas. Requires a confirmation per app unless --yes is
+# passed. Use --dry-run to preview.
 #
 # Usage:
-#   ./postgres-restore-all.sh [--yes] [--dry-run] [--no-restore-empty] \
-#                             [--apps "lubelog teslamate"]
+#   ./postgres-restore-all.sh [--yes] [--dry-run] [--apps "lubelog teslamate"]
 #
 # Flags:
-#   --yes               skip the per-app "delete cluster?" confirmation
-#   --dry-run           print the commands without running the mutating ones
-#   --no-restore-empty  skip the restore Job for apps with no NFS dump (tracearr)
-#   --apps "a b c"      restrict to a subset (default: all six)
+#   --yes          skip the per-app "delete cluster?" confirmation
+#   --dry-run      print the commands without running the mutating ones
+#   --apps "a b c" restrict to a subset (default: all six)
 #
 set -uo pipefail
 
@@ -53,15 +58,14 @@ CLUSTER_READY_TIMEOUT="${CLUSTER_READY_TIMEOUT:-600}"   # seconds
 RESTORE_TIMEOUT="${RESTORE_TIMEOUT:-3600}"              # seconds (teslamate is big)
 
 APPS="baby-tracker lubelog sparkyfitness teslamate tracearr readmeabook"
-ASSUME_YES=0; DRY_RUN=0; RESTORE_EMPTY=1
+ASSUME_YES=0; DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --yes) ASSUME_YES=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
-    --no-restore-empty) RESTORE_EMPTY=0; shift ;;
     --apps) APPS="$2"; shift 2 ;;
-    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,34p' "$0"; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -74,7 +78,7 @@ run() {   # run a mutating command (respects --dry-run)
 
 confirm() {
   [[ "$ASSUME_YES" == 1 ]] && return 0
-  read -r -p "  → delete cluster ${1}-db in ns/${2} and re-bootstrap EMPTY? [y/N] " ans
+  read -r -p "  → ${1}: DELETE & rebuild cluster ${1}-db in ns/${2}? (n = reset schemas in place) [y/N] " ans
   [[ "$ans" == "y" || "$ans" == "Y" ]]
 }
 
@@ -104,6 +108,72 @@ wait_cronjob() {   # ns app  — ensure Flux has created the restore CronJob
   done
 }
 
+workload_ref() {   # ns app -> "deploy/<app>" or "statefulset/<app>" (best-effort)
+  local ns="$1" app="$2"
+  if kubectl -n "$ns" get deploy "$app" >/dev/null 2>&1; then echo "deploy/${app}"
+  elif kubectl -n "$ns" get statefulset "$app" >/dev/null 2>&1; then echo "statefulset/${app}"
+  else echo ""; fi
+}
+
+primary_pod() {    # ns app -> primary CNPG pod name
+  kubectl -n "$1" get pod -l "cnpg.io/cluster=${2}-db,cnpg.io/instanceRole=primary" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Suspend Flux for the app and scale its workload to 0, so it can't (re)create
+# its own schema while we reset+restore. Records original replicas in globals.
+QUIESCED_WORKLOAD=""; QUIESCED_REPLICAS=1
+CUR_NS=""; CUR_APP=""; CUR_FNS=""   # for the interrupt trap
+quiesce_app() {    # ns app fns
+  local ns="$1" app="$2" fns="$3"
+  CUR_NS="$ns"; CUR_APP="$app"; CUR_FNS="$fns"
+  echo "  quiescing ${app}: suspend flux + scale workload to 0"
+  run flux -n "$fns" suspend kustomization "$app" || true
+  run flux -n "$ns" suspend helmrelease "$app" || true
+  QUIESCED_WORKLOAD="$(workload_ref "$ns" "$app")"; QUIESCED_REPLICAS=1
+  if [[ -n "$QUIESCED_WORKLOAD" ]]; then
+    QUIESCED_REPLICAS="$(kubectl -n "$ns" get "$QUIESCED_WORKLOAD" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)"
+    [[ -z "$QUIESCED_REPLICAS" ]] && QUIESCED_REPLICAS=1
+    run kubectl -n "$ns" scale "$QUIESCED_WORKLOAD" --replicas=0
+    [[ "$DRY_RUN" == 1 ]] || kubectl -n "$ns" rollout status "$QUIESCED_WORKLOAD" --timeout=120s 2>/dev/null || true
+  else
+    echo "  WARN: no deploy/statefulset named '${app}' to scale down" >&2
+  fi
+}
+
+unquiesce_app() {  # ns app fns  — always call to undo quiesce_app
+  local ns="$1" app="$2" fns="$3"
+  echo "  restoring ${app}: scale back + resume flux"
+  [[ -n "$QUIESCED_WORKLOAD" ]] && run kubectl -n "$ns" scale "$QUIESCED_WORKLOAD" --replicas="${QUIESCED_REPLICAS:-1}"
+  run flux -n "$ns" resume helmrelease "$app" || true
+  run flux -n "$fns" resume kustomization "$app" || true
+  QUIESCED_WORKLOAD=""; QUIESCED_REPLICAS=1
+}
+
+# Drop every non-system schema so the dump restores into a pristine DB. Apps
+# self-migrate their schema (e.g. lubelog creates schema "app"), which collides
+# with the dump's CREATE SCHEMA; this clears it first. Runs as the in-pod
+# superuser (peer auth); psql var :owner carries the app/owner name safely.
+reset_db() {       # ns app
+  local ns="$1" app="$2" pod; pod="$(primary_pod "$ns" "$app")"
+  if [[ -z "$pod" ]]; then echo "  ERROR: no primary pod for ${app}-db" >&2; return 1; fi
+  echo "  resetting database '${app}' (drop user schemas) via ${pod}"
+  [[ "$DRY_RUN" == 1 ]] && { echo "  (dry-run: skip reset)"; return 0; }
+  kubectl -n "$ns" exec -i "$pod" -c postgres -- \
+    psql -U postgres -d "$app" -v ON_ERROR_STOP=1 -v owner="$app" <<'SQL'
+DO $reset$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT nspname FROM pg_namespace
+           WHERE nspname !~ '^pg_' AND nspname <> 'information_schema'
+  LOOP EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE', r.nspname); END LOOP;
+END
+$reset$;
+CREATE SCHEMA public AUTHORIZATION :"owner";
+GRANT ALL ON SCHEMA public TO :"owner";
+SQL
+}
+
 do_app() {
   local app="$1" ns="${NS[$1]}" dump="${HAS_DUMP[$1]}"
   echo
@@ -113,35 +183,44 @@ do_app() {
 
   local fns="${FLUX_NS:-$ns}"   # Flux Kustomization lives in the app's namespace
 
+  if [[ "$dump" == "no" ]]; then
+    echo "  ${app}: no NFS dump — leaving the app-initialized empty database as-is."
+    return 0
+  fi
+
   # 1. reconcile the merged config
   run flux -n "$fns" reconcile kustomization "$app" --with-source || \
     echo "  WARN: reconcile failed/absent for ${app} (continuing)"
 
-  # 2. recreate the cluster empty
+  # 2. get an empty initdb cluster ready. Delete+rebuild guarantees a clean
+  #    initdb cluster with the right dbname; declining resets + restores in
+  #    place (faster, for clusters already on initdb). The reset in step 3
+  #    empties either way.
   if kubectl -n "$ns" get cluster "${app}-db" >/dev/null 2>&1; then
     if confirm "$app" "$ns"; then
       run kubectl -n "$ns" delete cluster "${app}-db" --wait=true
+      run flux -n "$fns" reconcile kustomization "$app" || true   # recreate empty
     else
-      echo "  skipped delete for ${app}; leaving existing cluster as-is."
-      return 0
+      echo "  keeping existing ${app}-db; will reset schemas + restore in place."
     fi
   else
     echo "  no existing ${app}-db cluster; Flux will create it fresh."
+    run flux -n "$fns" reconcile kustomization "$app" || true
   fi
-
-  # let Flux recreate the empty cluster, then wait for readiness
-  run flux -n "$fns" reconcile kustomization "$app" || true
   wait_cluster_ready "$ns" "$app" || { echo "  ABORT ${app}: cluster not ready"; return 1; }
+  wait_cronjob "$ns" "$app"       || { echo "  ABORT ${app}: no restore CronJob"; return 1; }
 
-  # 3. restore from NFS
-  if [[ "$dump" == "no" && "$RESTORE_EMPTY" == 0 ]]; then
-    echo "  ${app} has no NFS dump and --no-restore-empty set; leaving cluster empty."
-    return 0
+  # 3. quiesce the app, reset the DB, restore, then bring the app back
+  quiesce_app "$ns" "$app" "$fns"
+  if ! reset_db "$ns" "$app"; then
+    echo "  ❌ ${app}: DB reset failed; skipping restore"
+    unquiesce_app "$ns" "$app" "$fns"
+    return 1
   fi
-  wait_cronjob "$ns" "$app" || { echo "  ABORT ${app}: no restore CronJob"; return 1; }
+
   local job="${app}-restore-$(date +%s)"
   run kubectl -n "$ns" create job --from="cronjob/${app}-postgres-restore" "$job"
-  [[ "$DRY_RUN" == 1 ]] && return 0
+  if [[ "$DRY_RUN" == 1 ]]; then unquiesce_app "$ns" "$app" "$fns"; return 0; fi
 
   echo "  following ${job} ..."
   kubectl -n "$ns" wait --for=condition=complete "job/${job}" --timeout="${RESTORE_TIMEOUT}s" &
@@ -151,13 +230,21 @@ do_app() {
   if kubectl -n "$ns" get job "$job" -o jsonpath='{.status.succeeded}' | grep -q 1; then
     echo "  ✅ ${app} restore complete"
   else
-    if [[ "$dump" == "no" ]]; then
-      echo "  ℹ️  ${app} restore Job did not succeed — expected (no NFS dump); cluster stays empty."
-    else
-      echo "  ❌ ${app} restore Job did NOT succeed — investigate: kubectl -n ${ns} logs job/${job}"
-    fi
+    echo "  ❌ ${app} restore Job did NOT succeed — investigate: kubectl -n ${ns} logs job/${job}"
+  fi
+
+  unquiesce_app "$ns" "$app" "$fns"
+}
+
+# If interrupted mid-restore, undo the quiesce so we never leave an app
+# suspended and scaled to zero.
+cleanup_on_exit() {
+  if [[ -n "${QUIESCED_WORKLOAD:-}" && -n "${CUR_APP:-}" ]]; then
+    echo "  interrupted — bringing ${CUR_APP} back up..." >&2
+    unquiesce_app "$CUR_NS" "$CUR_APP" "$CUR_FNS"
   fi
 }
+trap cleanup_on_exit EXIT INT TERM
 
 echo "Apps: $APPS"
 echo "Flux Kustomization namespace: ${FLUX_NS:-<per-app>}   dry-run: $DRY_RUN   assume-yes: $ASSUME_YES"


### PR DESCRIPTION
## Problem

The restore assumed an empty target DB, but every app **self-migrates its schema on boot**. When a cluster comes up empty, the app connects and creates its schema (lubelog uses schema `app`, with all its tables) before the restore runs — so the dump's `CREATE SCHEMA app` hits `schema "app" already exists` and the `--single-transaction` restore rolls back.

## Fix (`postgres-restore-all.sh`)

Per app with a dump:
1. reconcile → (optionally) delete + rebuild the cluster empty → wait Ready
2. **quiesce**: `flux suspend kustomization` + `flux suspend helmrelease` + scale the workload to 0 (so the app can't repopulate or be scaled back mid-restore)
3. **reset**: drop all non-system schemas as the in-pod `postgres` superuser (peer auth), recreate `public`
4. run the restore Job, follow to completion
5. **unquiesce**: scale back to original replicas + resume Flux

Extras:
- **Interrupt-safe**: an `EXIT/INT/TERM` trap runs unquiesce, so a Ctrl-C never leaves an app suspended and scaled to 0.
- Declining the delete prompt now **resets + restores in place** (fast path for clusters already on `initdb`) instead of skipping the app.
- No-dump apps (tracearr) are skipped and left app-initialized.
- Removed the now-unused `--no-restore-empty` flag.

Validated the manual equivalent end-to-end on lubelog (restore Job `1/1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)