### PR TITLE
revert(longhorn): switch data engine back to V1 (iSCSI)

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -15,18 +15,17 @@ spec:
       upgradeVersionCheck: false
     persistence:
       defaultDataLocality: best-effort
-      dataEngine: v2
       recurringJobSelector:
         enable: true
         jobList: '[{"name":"recurring-fs-trim", "isGroup":false}]'
     defaultSettings:
-      # Pure V2 (SPDK/NVMe-TCP) build. V1 is disabled so the host open-iscsi stack
-      # is never used — see docs/notes/longhorn-iscsi-attaching.md for why.
-      v2DataEngine: true
-      v1DataEngine: false
-      defaultDataEngine: v2
-      # No defaultDataPath: V2 disks are raw block devices, registered per node via
-      # the node.longhorn.io/default-disks-config annotation (talconfig.yaml).
+      # V1 (iSCSI) data engine. Reverted from the V2/SPDK build, which hit a
+      # v2 NVMe-TCP device-number-reuse race in Longhorn v1.12.0 (frontend flips
+      # app ext4 read-only). Data disk is a filesystem userVolume at
+      # /var/mnt/longhorn (talconfig.yaml + machine-nodelabel.yaml).
+      v2DataEngine: false
+      defaultDataEngine: v1
+      defaultDataPath: "/var/mnt/longhorn"
       replicaDiskSoftAntiAffinity: false
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort
@@ -36,12 +35,9 @@ spec:
       guaranteedReplicaManagerCPU: "20"
       nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
       orphanAutoDeletion: replica-data;instance
-      # replicaAutoBalance disabled + rebuild concurrency pinned to 1 to avoid a v2
-      # NVMe-TCP device-number-reuse race in Longhorn v1.12.0: concurrent replica
-      # attach/detach churn made one volume's frontend validate another's freed
-      # /dev/nvmeXn1 ("no subsystem found for NVMe device"), erroring the frontend and
-      # flipping the app's ext4 read-only. On a 3-node/3-replica cluster replicas are
-      # already fully spread, so auto-balance was pure churn. See docs/notes below.
+      # Conservative rebuild behavior: on a 3-node/3-replica cluster replicas are
+      # already fully spread, so auto-balance is pure churn; serialize rebuilds to
+      # limit disk/network pressure during recovery.
       replicaAutoBalance: disabled
       concurrentReplicaRebuildPerNodeLimit: "1"
       storageMinimalAvailablePercentage: "1"

--- a/kubernetes/apps/longhorn-system/longhorn/storageclass/snapshot.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/storageclass/snapshot.yaml
@@ -6,7 +6,7 @@ provisioner: driver.longhorn.io
 parameters:
   # used for volsync to copy from.
   # we set this to 1 replica for faster restores from the snapclass
-  dataEngine: v2
+  dataEngine: v1
   dataLocality: disabled
   numberOfReplicas: "1"
   replicaAutoBalance: best-effort
@@ -22,7 +22,7 @@ reclaimPolicy: Delete
 provisioner: driver.longhorn.io
 parameters:
   # we set this to 1 replica for less copies of the cache, which can be blown away safely.
-  dataEngine: v2
+  dataEngine: v1
   dataLocality: disabled
   numberOfReplicas: "1"
   replicaAutoBalance: best-effort
@@ -42,4 +42,4 @@ driver: driver.longhorn.io
 deletionPolicy: Delete
 parameters:
   type: snap
-  dataEngine: v2
+  dataEngine: v1

--- a/talos/patches/global/machine-kernel.yaml
+++ b/talos/patches/global/machine-kernel.yaml
@@ -2,7 +2,4 @@ machine:
   kernel:
     modules:
       - name: nbd
-      - name: nvme_tcp          # V2 frontend transport (replaces iSCSI)
-      - name: uio_pci_generic   # SPDK device binding
-      # - name: vfio_pci        # alternative to uio_pci_generic if needed
       # - name: thunderbolt

--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -3,7 +3,14 @@ machine:
     extraConfig:
       serializeImagePulls: false
       imageMaximumGCAge: 24h
-    # No Longhorn bind-mount: V2 uses a raw block device, not a /var/mnt filesystem path.
+    extraMounts:
+      - destination: /var/mnt/longhorn
+        type: bind
+        source: /var/mnt/longhorn
+        options:
+          - "bind"
+          - "rshared"
+          - "rw"
     defaultRuntimeSeccompProfileEnabled: true
     nodeIP:
       validSubnets:

--- a/talos/patches/global/machine-nodelabel.yaml
+++ b/talos/patches/global/machine-nodelabel.yaml
@@ -1,6 +1,6 @@
 machine:
-  # Longhorn V2: the per-node "default-disks-config" annotation (block disk, by-id path)
-  # is defined per node in talconfig.yaml, since the device path differs per host.
+  nodeAnnotations:
+    node.longhorn.io/default-disks-config: '[{"path":"/var/mnt/longhorn","allowScheduling":true}]'
   nodeLabels:
     node.longhorn.io/create-default-disk: "config"
     node.kubernetes.io/gpu: "true"

--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -27,4 +27,3 @@ machine:
     vm.dirty_ratio: "20"                        # Cap dirty page buildup
     vm.dirty_expire_centisecs: "3000"           # Expire dirty data after 30s
     vm.dirty_writeback_centisecs: "500"         # Flush dirty pages every 5s
-    vm.nr_hugepages: "1024"                     # 1024 * 2MiB = 2GiB reserved for SPDK (Longhorn V2)

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -26,10 +26,13 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/8af8cf71310e5eeddc32fa523441d6a0f181e0fb859e66bf7dbed7affb2e73c9
     controlPlane: true
-    # Longhorn V2 data disk (nvme0n1, KINGSTON OM8PGP41024N-A0, serial 50026B73839504FD): left RAW so SPDK uses it directly.
-    # Registered as a V2 "block" disk by its NVMe EUI id (WWID confirmed via `talosctl get disks`).
-    nodeAnnotations:
-      node.longhorn.io/default-disks-config: '[{"path":"/dev/disk/by-id/nvme-eui.00000000000000000026b73839504fd5","allowScheduling":true,"diskType":"block"}]'
+    userVolumes:
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.serial == "50026B73839504FD"
+          minSize: "300GiB"
+          grow: true
     networkInterfaces:
       - interface: bond0
         bond:
@@ -53,10 +56,13 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/8af8cf71310e5eeddc32fa523441d6a0f181e0fb859e66bf7dbed7affb2e73c9
     controlPlane: true
-    # Longhorn V2 data disk (nvme0n1, KINGSTON OM8PGP41024N-A0, serial 50026B7383950E6D): left RAW so SPDK uses it directly.
-    # Registered as a V2 "block" disk by its NVMe EUI id (WWID confirmed via `talosctl get disks`).
-    nodeAnnotations:
-      node.longhorn.io/default-disks-config: '[{"path":"/dev/disk/by-id/nvme-eui.00000000000000000026b7383950e6d5","allowScheduling":true,"diskType":"block"}]'
+    userVolumes:
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.serial == "50026B7383950E6D"
+          minSize: "300GiB"
+          grow: true
     networkInterfaces:
       - interface: bond0
         bond:
@@ -76,10 +82,13 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/8af8cf71310e5eeddc32fa523441d6a0f181e0fb859e66bf7dbed7affb2e73c9
     controlPlane: true
-    # Longhorn V2 data disk (nvme0n1, KINGSTON OM8PGP41024N-A0, serial 50026B7383951A37): left RAW so SPDK uses it directly.
-    # Registered as a V2 "block" disk by its NVMe EUI id (WWID confirmed via `talosctl get disks`).
-    nodeAnnotations:
-      node.longhorn.io/default-disks-config: '[{"path":"/dev/disk/by-id/nvme-eui.00000000000000000026b7383951a375","allowScheduling":true,"diskType":"block"}]'
+    userVolumes:
+      - name: longhorn
+        provisioning:
+          diskSelector:
+            match: disk.serial == "50026B7383951A37"
+          minSize: "300GiB"
+          grow: true
     networkInterfaces:
       - interface: bond0
         bond:


### PR DESCRIPTION
Reverts the Longhorn V2 (SPDK/NVMe-TCP) build back to the V1 iSCSI engine. V2 kept hitting a device-number-reuse race in v1.12.0 (frontend flips app ext4 read-only); the `replicaAutoBalance: disabled` + serialized-rebuild mitigations didn't hold.

## Config changes (this PR — non-destructive)
- **talconfig.yaml** — each node's data disk (`nvme0n1`, by serial) back to a filesystem `longhorn` userVolume (was a raw V2 block-disk annotation).
- **machine patches** — restore the `/var/mnt/longhorn` kubelet bind-mount and the `default-disks-config` node annotation; drop `nvme_tcp`/`uio_pci_generic` modules and `vm.nr_hugepages`.
- **helmrelease** — `v2DataEngine: false`, `defaultDataEngine: v1`, restore `defaultDataPath: /var/mnt/longhorn` (kept the conservative `replicaAutoBalance: disabled` + `concurrentReplicaRebuildPerNodeLimit: 1`).
- **storageclasses** — `dataEngine: v1`.

## ⚠️ Required follow-up (destructive — NOT in this PR)
V1 and V2 can't share the single data disk, so after merge:
1. `just talos reset-wipe-data` (or per-node `wipe disk nvme0n1`) — reformats `nvme0n1` from V2 raw block → V1 xfs, **wiping all current Longhorn volumes**.
2. Re-bootstrap on V1; Longhorn creates its default disk at `/var/mnt/longhorn`.
3. Restore all app/DB data from backup (volsync → R2 + barman) — same scope as the rebuild.

Merging this PR alone changes only git; the live cluster is unaffected until the wipe/bootstrap above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)